### PR TITLE
Temporary redesign of professor popup UI

### DIFF
--- a/src/ProfessorPopup.tsx
+++ b/src/ProfessorPopup.tsx
@@ -139,7 +139,7 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
         <Typography
           style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#008970' }}
         >
-          {props.professorName.toUpperCase()}
+          {ProfessorNameFiltering(props.professorName.toUpperCase())}
         </Typography>
       </Paper>
       <Divider style={{ margin: '10px 0' }} />

--- a/src/ProfessorPopup.tsx
+++ b/src/ProfessorPopup.tsx
@@ -127,20 +127,19 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
     color: '#1c1c1c',
   };
 
+  const centerItems = {
+    display: 'flex',
+    justifyContent: 'center',
+    alignItems: 'center',
+  };
+
   return loading ? (
     <>
-      <Paper
-        style={{
-          height: '100%',
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
+      <Paper style={{ ...centerItems, marginTop: '10px' }}>
         <Typography
-          style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'black' }}
+          style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#008970' }}
         >
-          {props.professorName}
+          {props.professorName.toUpperCase()}
         </Typography>
       </Paper>
       <Divider style={{ margin: '10px 0' }} />
@@ -159,6 +158,9 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
       <span style={boldStyle}>{retentionPercent}% </span>
       <span style={unboldStyle}>would take again</span>
       <Divider style={{ margin: '10px 0' }} />
+      <Paper style={centerItems}>
+        <Button onClick={props.handleTooltipClose}>Close</Button>
+      </Paper>
     </>
   ) : (
     <img

--- a/src/ProfessorPopup.tsx
+++ b/src/ProfessorPopup.tsx
@@ -1,4 +1,11 @@
-import { Button, ClickAwayListener, Tooltip } from '@mui/material';
+import {
+  Button,
+  ClickAwayListener,
+  Divider,
+  Paper,
+  Tooltip,
+  Typography,
+} from '@mui/material';
 import React, { useState, useEffect } from 'react';
 
 interface professorPopupTooltipProps {
@@ -80,7 +87,7 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
 
   const [avgDifficulty, setAvgDifficulty] = useState(null); // avgDifficulty
   const [avgRating, setAvgRating] = useState(null); // avgRating
-  const [numRatings, setNumRatings] = useState(null); // numRatings
+  const [numReviews, setNumReviews] = useState(null); // numReviews
   const [retentionPercent, setRetentionPercent] = useState(null); // wouldTakeAgainPercent
 
   const [loading, setLoading] = useState(false);
@@ -94,7 +101,7 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
 
       setAvgDifficulty(json.avgDifficulty);
       setAvgRating(json.avgRating);
-      setNumRatings(json.numRatings);
+      setNumReviews(json.numRatings);
       setRetentionPercent(json.wouldTakeAgainPercent.toFixed(2)); // truncate to 2 decimal points (don't think it rounds atm)
 
       setLoading(true); // data finished loading
@@ -108,28 +115,50 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
     void getProfessorData();
   }, []);
 
+  const boldStyle = {
+    fontSize: '1.25rem',
+    fontWeight: 'bold',
+    color: 'black',
+  };
+
+  const unboldStyle = {
+    fontSize: '1.25rem',
+    fontWeight: 'normal',
+    color: '#1c1c1c',
+  };
+
   return loading ? (
     <>
-      <h1>{ProfessorNameFiltering(props.professorName)}</h1>
-      <h3>
-        Score: {avgRating} / 5
-        <br />
-        Difficulty: {avgDifficulty} / 5
-        <br />
-        Ratings: {numRatings}
-        <br />
-        {retentionPercent}% would take again
-      </h3>
-      <Button
-        onClick={props.handleTooltipClose}
+      <Paper
         style={{
-          position: 'absolute',
-          top: 0,
-          right: 0,
+          height: '100%',
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
         }}
       >
-        Close
-      </Button>
+        <Typography
+          style={{ fontSize: '1.5rem', fontWeight: 'bold', color: 'black' }}
+        >
+          {props.professorName}
+        </Typography>
+      </Paper>
+      <Divider style={{ margin: '10px 0' }} />
+      <Typography>
+        <span style={boldStyle}>Rating: </span>
+        <span style={unboldStyle}>{avgRating}</span>
+      </Typography>
+      <Typography>
+        <span style={boldStyle}>Difficulty: </span>
+        <span style={unboldStyle}>{avgDifficulty}</span>
+      </Typography>
+      <Typography>
+        <span style={boldStyle}>Reviews: </span>
+        <span style={unboldStyle}>{numReviews}</span>
+      </Typography>
+      <span style={boldStyle}>{retentionPercent}% </span>
+      <span style={unboldStyle}>would take again</span>
+      <Divider style={{ margin: '10px 0' }} />
     </>
   ) : (
     <img


### PR DESCRIPTION
There are many restrictions with the portal's styling that makes some major MUI components not work (more notably Grid and some innate stylings in Button). It was very frustrating to deal with, and the UI itself is still pretty barebones but gets the job done.

- Changed color of professor name (also capitalized)
- Data points are sorta styled
- Moved placement of close button

Preferably change the Click/Close buttons to actual icons (and maybe even the data points), but I couldn't figure out how to actually get icons in the portal (mui icons don't work).

Also, the font size is very wonky to work with. It aligns properly with how it's styled in the code when the browser's window is kinda minimized, but when it's nearly fullscreen the text seems to auto-shrink. I'm not sure why, just gonna blame it on portal styling again.

![image](https://user-images.githubusercontent.com/24869207/213819628-98aa8582-95ab-4520-8704-875a63099119.png)