### PR TITLE
RMP Button Injection fix & manifest.json updates

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BroncoDirectMe",
-  "description": "Test Description",
-  "version": "1.0",
+  "description": "A Chrome Extension for BroncoDirect to be used by Cal Poly Pomona students.",
+  "version": "1.0.1",
   "manifest_version": 3,
   "action": {
     "default_popup": "index.html",
@@ -12,11 +12,17 @@
       "128": "/images/icon.png"
     }
   },
-  "permissions": ["activeTab", "storage", "tabs", "identity", "identity.email"],
+  "icons": {
+    "16": "/images/icon.png",
+    "48": "/images/icon.png",
+    "128": "/images/icon.png"
+  },
+  "permissions": ["storage", "identity", "identity.email"],
   "content_scripts": [
     {
       "js": ["content.js"],
-      "matches": ["https://cmsweb.cms.cpp.edu/*"]
+      "matches": ["https://cmsweb.cms.cpp.edu/*"],
+      "all_frames": true
     }
   ],
   "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsLI8exOzJjueuW38zjxD5blonDds7/7WF0bX+VanMM6RGyVyiXcWYYkxJX7y+ZXYYt8TNhDfKmkei3WZmQEMuepj6p9voxxptgrqOqFpD2FxeytLhReuXHW/YnJJDQ+VCj5I5wMUaMiA7zmUNaKrEWq4Uz97494l3f5LPKp3cPCY0G/cTgtvNPKICk7HRGgT9MZ93zaRpUQ/V/FYKVPDhbHr4v3Nnmd6flFs2ScuFVNvuLOTdZ8k+9e3GGVsNG0xn1cEj0x8b/NfNecRymy1WZZqYGc2dYfc9FA3a4jove5KmHynL4VW6kzxu4pgROMad9v4eaRgtF+DjHln+bdF9wIDAQAB"

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "BroncoDirectMe",
   "description": "A Chrome Extension for BroncoDirect to be used by Cal Poly Pomona students.",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "manifest_version": 3,
   "action": {
     "default_popup": "index.html",

--- a/src/Content.tsx
+++ b/src/Content.tsx
@@ -6,73 +6,87 @@ import RateMyProfessorButton from './RateMyProfessorButton';
 
 let searchResultsTrue = false;
 
-if (document.URL.includes('https://cmsweb.cms.cpp.edu/'))
-  console.log('BroncoDirect Page Loaded');
+function injectButtons(): void {
+  if (
+    window.self !== window.top || // Makes sure only the top window loads first and not the iframe window
+    !document.URL.includes('https://cmsweb.cms.cpp.edu/')
+  ) {
+    return;
+  }
+  console.log('[BRONCODIRECT] Page Loaded');
 
-if (
-  document.URL.includes(
-    'https://cmsweb.cms.cpp.edu/psp/CPOMPRDM/EMPLOYEE/SA/c/SA_LEARNER_SERVICES.CLASS_SEARCH.GBL?'
-  )
-) {
-  const iframe = document.getElementById('ptifrmtgtframe') as HTMLIFrameElement;
+  if (
+    document.URL.includes(
+      'https://cmsweb.cms.cpp.edu/psp/CPOMPRDM/EMPLOYEE/SA/c/SA_LEARNER_SERVICES.CLASS_SEARCH.GBL?'
+    )
+  ) {
+    const iframe = document.getElementById(
+      'ptifrmtgtframe'
+    ) as HTMLIFrameElement;
 
-  // event listener on the iframe which fires on search
-  // since iframe will receive a post message of the search criteria
-  // however event will fire regardless if the search criteria is invalid and will remain on the page
-  iframe?.contentWindow?.addEventListener('click', () => {
-    const insts: NodeListOf<HTMLElement> | undefined =
-      iframe.contentWindow?.document.querySelectorAll('*[id^="MTG_INSTR$"]');
+    // event listener on the iframe which fires on search
+    // since iframe will receive a post message of the search criteria
+    // however event will fire regardless if the search criteria is invalid and will remain on the page
+    iframe?.contentWindow?.addEventListener('click', () => {
+      const insts: NodeListOf<HTMLElement> | undefined =
+        iframe.contentWindow?.document.querySelectorAll('*[id^="MTG_INSTR$"]');
 
-    const header: HTMLElement | null | undefined =
-      iframe.contentWindow?.document.querySelector('.gh-page-header-headings');
+      const header: HTMLElement | null | undefined =
+        iframe.contentWindow?.document.querySelector(
+          '.gh-page-header-headings'
+        );
 
-    // Log to console the current page of Bronco Direct (using the header of the page)
-    if (header !== undefined && header !== null) {
-      console.log((header.children[2] as HTMLElement).innerText);
+      // Log to console the current page of Bronco Direct (using the header of the page)
+      if (header !== undefined && header !== null) {
+        console.log((header.children[2] as HTMLElement).innerText);
 
-      if ((header.children[2] as HTMLElement).innerText === 'Search Results') {
-        if (!searchResultsTrue) {
-          // iterate through insts and create new instance of ProfessorPopup & UpvoteDownvoteButton for each inst
-          insts?.forEach((inst) => {
-            // append new root containers under inst.parent to retain original span element
-            const professorPopupRoot = document.createElement('div');
-            const rateMyProfessorRoot = document.createElement('div');
-            // const upvoteDownvoteRoot = document.createElement('div');
-            const parentElem = inst.parentElement as HTMLDivElement;
+        if (
+          (header.children[2] as HTMLElement).innerText === 'Search Results'
+        ) {
+          if (!searchResultsTrue) {
+            // iterate through insts and create new instance of ProfessorPopup & UpvoteDownvoteButton for each inst
+            insts?.forEach((inst) => {
+              // append new root containers under inst.parent to retain original span element
+              const professorPopupRoot = document.createElement('div');
+              const rateMyProfessorRoot = document.createElement('div');
+              // const upvoteDownvoteRoot = document.createElement('div');
+              const parentElem = inst.parentElement as HTMLDivElement;
 
-            // styling for the ProfessorPopup Button
-            professorPopupRoot.setAttribute('id', 'professorPopupRoot');
-            professorPopupRoot.style.float = 'right';
-            parentElem?.append(professorPopupRoot);
+              // styling for the ProfessorPopup Button
+              professorPopupRoot.setAttribute('id', 'professorPopupRoot');
+              professorPopupRoot.style.float = 'right';
+              parentElem?.append(professorPopupRoot);
 
-            // styling for RateMyProfessor Button
-            rateMyProfessorRoot.setAttribute('id', 'rateMyProfessorRoot');
-            rateMyProfessorRoot.style.flex = 'right';
-            parentElem?.append(rateMyProfessorRoot);
+              // styling for RateMyProfessor Button
+              rateMyProfessorRoot.setAttribute('id', 'rateMyProfessorRoot');
+              rateMyProfessorRoot.style.flex = 'right';
+              parentElem?.append(rateMyProfessorRoot);
 
-            // Styling for the UpvoteDownvote Button
-            // upvoteDownvoteRoot.setAttribute('id', 'upvoteDownvoteRoot');
-            // upvoteDownvoteRoot.style.float = 'left';
-            // upvoteDownvoteRoot.style.padding = '2%';
-            // parentElem?.prepend(upvoteDownvoteRoot);
+              // Styling for the UpvoteDownvote Button
+              // upvoteDownvoteRoot.setAttribute('id', 'upvoteDownvoteRoot');
+              // upvoteDownvoteRoot.style.float = 'left';
+              // upvoteDownvoteRoot.style.padding = '2%';
+              // parentElem?.prepend(upvoteDownvoteRoot);
 
-            // createRoot(upvoteDownvoteRoot).render(
-            //   <UpvoteDownvoteButton professorName={inst.innerText} />
-            // );
+              // createRoot(upvoteDownvoteRoot).render(
+              //   <UpvoteDownvoteButton professorName={inst.innerText} />
+              // );
 
-            createRoot(rateMyProfessorRoot).render(
-              <RateMyProfessorButton professorName={inst.innerText} />
-            );
+              createRoot(rateMyProfessorRoot).render(
+                <RateMyProfessorButton professorName={inst.innerText} />
+              );
 
-            createRoot(professorPopupRoot).render(
-              <ProfessorPopup professorName={inst.innerText} />
-            );
-          });
-          searchResultsTrue = true;
-        }
-      } else searchResultsTrue = false;
-    } else console.log('undefined');
-  });
+              createRoot(professorPopupRoot).render(
+                <ProfessorPopup professorName={inst.innerText} />
+              );
+            });
+            searchResultsTrue = true;
+          }
+        } else searchResultsTrue = false;
+      } else console.log('undefined');
+    });
+  }
 }
 
+injectButtons();
 console.log(document.URL);

--- a/src/ProfessorPopup.tsx
+++ b/src/ProfessorPopup.tsx
@@ -82,7 +82,7 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
   const body = {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ name: props.professorName }),
+    body: JSON.stringify({ name: ProfessorNameFiltering(props.professorName) }),
   };
 
   const [avgDifficulty, setAvgDifficulty] = useState(null); // avgDifficulty
@@ -139,7 +139,7 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
         <Typography
           style={{ fontSize: '1.5rem', fontWeight: 'bold', color: '#008970' }}
         >
-          {ProfessorNameFiltering(props.professorName.toUpperCase())}
+          {ProfessorNameFiltering(props.professorName).toUpperCase()}
         </Typography>
       </Paper>
       <Divider style={{ margin: '10px 0' }} />


### PR DESCRIPTION
Pages with double names and/or "To be Announced" don't work with the injection because the code tried to account for those but failed. Apparently if the buttons don't inject for 1 name it won't inject for them all on a page.

~~This has been fixed with a small change to how the frontend calls the backend, so this base-case now works.
Note that the injection issue still exists and likely has to do with DOM element loading. This is mitigated with using a 'click' to load the buttons and manifest.json's "all_frame" content script.~~
UPDATE:
The core issue was the fact that the extension's Content.tsx script ran twice every time the course catalog section of the portal loaded. The first time it loads is when the main window loads, and the script works perfectly fine. Upon the second load, it doesn't detect the URL as being valid so it skips the injection process. This is fixed by forcing the script to only load the main window and ignore the iframe window.

For some reason, the script doesn't run when loading actual courses to pick from. What happens is that once it successfully validates the URL as being the course catalog, it'll run the injection part of the script every time the user clicks (via the iframe eventListener 'click') regardless of whereever the user is (as long as they are in the course catalog section); it doesn't detect page reloads, it maintains the very first validation and guarantees button injection afterwards.

**I am unsure if there are special cases with this fix, but hopefully this resolves the injection failure problem.**

Speaking of which, I also updated the manifest.json for the chrome extension to properly work.