### PR TITLE
Leaf/mint napkin/new update notification

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,10 +20,10 @@ export function App(): ReactElement {
 
   return (
     <MsalProvider instance={msalInstance}>
-      <UpdateAlert />
       <div className="App">
         {!isPanelOpen && (
           <section>
+            <UpdateAlert />
             <div id="errorElm"></div>
             <Box id="mainContent">
               <h1>BroncoDirectMe Search</h1>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,7 @@ export function App(): ReactElement {
 
   return (
     <MsalProvider instance={msalInstance}>
+      <UpdateAlert />
       <div className="App">
         {!isPanelOpen && (
           <section>
@@ -55,7 +56,6 @@ export function App(): ReactElement {
           <ToggleButton />
         </Panel>
       </div>
-      <UpdateAlert/>
     </MsalProvider>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,6 +8,7 @@ import { Box, IconButton } from '@mui/material';
 import SettingsIcon from '@mui/icons-material/Settings';
 import { Panel } from './components/panel_component';
 import './styles/App.css';
+import UpdateAlert from './components/UpdateAlert';
 
 /**
  * @returns Main app component
@@ -54,6 +55,7 @@ export function App(): ReactElement {
           <ToggleButton />
         </Panel>
       </div>
+      <UpdateAlert/>
     </MsalProvider>
   );
 }

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -17,7 +17,11 @@ const UpdateAlert = (): JSX.Element => {
   }, []);
 
   const handleUpdateAvailable = (): void => {
-    setAlertVisible(true);
+    chrome.storage.local.get('alertClosed', ({ alertClosed }) => {
+      if (!alertClosed) {
+        setAlertVisible(true);
+      }
+    });
   };
 
   // the 'closed forever' status of the alert is reset when extension is updated

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -1,6 +1,10 @@
 import React, { useState, useEffect } from 'react';
 import { Alert } from '@mui/material';
 
+/**
+ * UpdateAlert component
+ * @returns An Alert component which notifies the user of a new update from the chrome web store
+ */
 const UpdateAlert = (): JSX.Element => {
   const [alertVisible, setAlertVisible] = useState(false);
 

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Alert } from '@mui/material';
 
 const UpdateAlert = (): JSX.Element => {
-  const [alertVisible, setAlertVisible] = useState(true);
+  const [alertVisible, setAlertVisible] = useState(false);
 
   useEffect(() => {
     chrome.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -1,12 +1,10 @@
-/*global chrome*/
 import React, { useState, useEffect } from 'react';
-import { Alert, Button } from '@mui/material';
+import { Alert } from '@mui/material';
 
 const UpdateAlert = (): JSX.Element => {
   const [alertOpen, setAlertOpen] = useState(false);
 
   useEffect(() => {
-    const str = chrome.runtime.getURL;
     // calls function when update is available
     chrome.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);
   }, []);
@@ -16,22 +14,13 @@ const UpdateAlert = (): JSX.Element => {
   };
 
   const handleCloseAlert = (): void => {
-    // updates the extension when it reloads, see onUpdateAvailable docs
-    chrome.runtime.reload;
     setAlertOpen(false);
   };
 
   // The Alert itself
   return alertOpen ? (
-    <Alert
-      action={
-        <Button onClick={handleCloseAlert} color="inherit" size="small">
-          UPDATE
-        </Button>
-      }
-      severity="info"
-    >
-      A new version is available!
+    <Alert onClose={handleCloseAlert} severity="info">
+      A new version is available! Please update.
     </Alert>
   ) : (
     <></>

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -1,35 +1,37 @@
+/*global chrome*/
 import React, { useState, useEffect } from 'react';
-import { Alert } from '@mui/material';
+import { Alert, Button } from '@mui/material';
 
 const UpdateAlert = (): JSX.Element => {
   const [alertOpen, setAlertOpen] = useState(false);
 
   useEffect(() => {
-    // Updated version number of the extension
-    const updatedVersion: string = '1.1.0'; // currently testing
-
-    // Current version number of the installed extension
-    const currentVersion: string = '1.0.0'; // currently testing
-
-    console.log(
-      `Updated Version: ${updatedVersion} || Current Version: ${currentVersion}`
-    );
-
-    // Compare the version numbers
-    if (currentVersion !== updatedVersion) {
-      setAlertOpen(true);
-    }
+    const str = chrome.runtime.getURL;
+    // calls function when update is available
+    chrome.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);
   }, []);
+
+  const handleUpdateAvailable = (): void => {
+    setAlertOpen(true);
+  };
+
+  const handleCloseAlert = (): void => {
+    // updates the extension when it reloads, see onUpdateAvailable docs
+    chrome.runtime.reload;
+    setAlertOpen(false);
+  };
 
   // The Alert itself
   return alertOpen ? (
     <Alert
-      onClose={() => {
-        setAlertOpen(false);
-      }}
+      action={
+        <Button onClick={handleCloseAlert} color="inherit" size="small">
+          UPDATE
+        </Button>
+      }
       severity="info"
     >
-      A new version is available! Please update.
+      A new version is available!
     </Alert>
   ) : (
     <></>
@@ -37,5 +39,3 @@ const UpdateAlert = (): JSX.Element => {
 };
 
 export default UpdateAlert;
-
-// testing

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -7,6 +7,13 @@ const UpdateAlert = (): JSX.Element => {
   useEffect(() => {
     // calls function when update is available
     chrome.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);
+
+    // does not appear again after closing update notif
+    chrome.storage.local.get('alertClosed', ({ alertClosed }) => {
+      if (alertClosed) {
+        setAlertOpen(false);
+      }
+    });
   }, []);
 
   const handleUpdateAvailable = (): void => {
@@ -15,6 +22,7 @@ const UpdateAlert = (): JSX.Element => {
 
   const handleCloseAlert = (): void => {
     setAlertOpen(false);
+    chrome.storage.local.set({ alertClosed: true });
   };
 
   // The Alert itself

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { Alert } from '@mui/material';
 
 const UpdateAlert = (): JSX.Element => {
-  const [alertOpen, setAlertOpen] = useState(false);
+  const [alertVisible, setAlertVisible] = useState(false);
 
   useEffect(() => {
     // calls function when update is available
@@ -11,17 +11,24 @@ const UpdateAlert = (): JSX.Element => {
     // does not appear again after closing update notif
     chrome.storage.local.get('alertClosed', ({ alertClosed }) => {
       if (alertClosed) {
-        setAlertOpen(false);
+        setAlertVisible(false);
       }
     });
   }, []);
 
   const handleUpdateAvailable = (): void => {
-    setAlertOpen(true);
+    setAlertVisible(true);
+    console.log(`Updated | alertClosed set to false`);
+    chrome.storage.local.set({ alertClosed: false }, () => {
+      if (chrome.runtime.lastError) {
+        console.error(chrome.runtime.lastError);
+      }
+    });
   };
 
   const handleCloseAlert = (): void => {
-    setAlertOpen(false);
+    console.log(`Alert closed! | alertClosed set to true`);
+    setAlertVisible(false);
     chrome.storage.local.set({ alertClosed: true }, () => {
       if (chrome.runtime.lastError) {
         console.error(chrome.runtime.lastError);
@@ -30,7 +37,7 @@ const UpdateAlert = (): JSX.Element => {
   };
 
   // The Alert itself
-  return alertOpen ? (
+  return alertVisible ? (
     <Alert onClose={handleCloseAlert} severity="info">
       A new version is available! Please update.
     </Alert>

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -1,0 +1,35 @@
+import React, { useState, useEffect } from 'react';
+import { Alert } from '@mui/material';
+
+const UpdateAlert = () => {
+  const [alertOpen, setAlertOpen] = useState(false);
+
+  useEffect(() => {
+    // Updated version number of the extension
+    const updatedVersion: string = '1.1.0'; // currently testing
+
+    // Current version number of the installed extension
+    const currentVersion: string = '1.0.0'; // currently testing
+
+    console.log(`Updated Version: ${updatedVersion} || Current Version: ${currentVersion}`);
+
+    // Compare the version numbers
+    if (currentVersion !== updatedVersion) {
+      setAlertOpen(true);
+    }
+  }, []);
+
+  // The Alert itself
+  return alertOpen ? (
+    <Alert
+      onClose={() => {
+        setAlertOpen(false);
+      }}
+      severity="info"
+    >
+      A new version is available! Please update.
+    </Alert>
+  ) : null;
+};
+
+export default UpdateAlert;

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Alert } from '@mui/material';
 
-const UpdateAlert = () => {
+const UpdateAlert = (): JSX.Element => {
   const [alertOpen, setAlertOpen] = useState(false);
 
   useEffect(() => {
@@ -11,7 +11,9 @@ const UpdateAlert = () => {
     // Current version number of the installed extension
     const currentVersion: string = '1.0.0'; // currently testing
 
-    console.log(`Updated Version: ${updatedVersion} || Current Version: ${currentVersion}`);
+    console.log(
+      `Updated Version: ${updatedVersion} || Current Version: ${currentVersion}`
+    );
 
     // Compare the version numbers
     if (currentVersion !== updatedVersion) {
@@ -29,7 +31,11 @@ const UpdateAlert = () => {
     >
       A new version is available! Please update.
     </Alert>
-  ) : null;
+  ) : (
+    <></>
+  );
 };
 
 export default UpdateAlert;
+
+// testing

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -2,11 +2,11 @@ import React, { useState, useEffect } from 'react';
 import { Alert } from '@mui/material';
 
 const UpdateAlert = (): JSX.Element => {
-  const [alertVisible, setAlertVisible] = useState(false);
+  const [alertVisible, setAlertVisible] = useState(true);
 
   useEffect(() => {
-    // calls function when update is available
     chrome.runtime.onUpdateAvailable.addListener(handleUpdateAvailable);
+    chrome.runtime.onInstalled.addListener(handleResetAlertClosedStatus);
 
     // does not appear again after closing update notif
     chrome.storage.local.get('alertClosed', ({ alertClosed }) => {
@@ -18,7 +18,10 @@ const UpdateAlert = (): JSX.Element => {
 
   const handleUpdateAvailable = (): void => {
     setAlertVisible(true);
-    console.log(`Updated | alertClosed set to false`);
+  };
+
+  // the 'closed forever' status of the alert is reset when extension is updated
+  const handleResetAlertClosedStatus = (): void => {
     chrome.storage.local.set({ alertClosed: false }, () => {
       if (chrome.runtime.lastError) {
         console.error(chrome.runtime.lastError);
@@ -26,8 +29,8 @@ const UpdateAlert = (): JSX.Element => {
     });
   };
 
+  // user closes the alert
   const handleCloseAlert = (): void => {
-    console.log(`Alert closed! | alertClosed set to true`);
     setAlertVisible(false);
     chrome.storage.local.set({ alertClosed: true }, () => {
       if (chrome.runtime.lastError) {

--- a/src/components/UpdateAlert.tsx
+++ b/src/components/UpdateAlert.tsx
@@ -22,7 +22,11 @@ const UpdateAlert = (): JSX.Element => {
 
   const handleCloseAlert = (): void => {
     setAlertOpen(false);
-    chrome.storage.local.set({ alertClosed: true });
+    chrome.storage.local.set({ alertClosed: true }, () => {
+      if (chrome.runtime.lastError) {
+        console.error(chrome.runtime.lastError);
+      }
+    });
   };
 
   // The Alert itself


### PR DESCRIPTION
New Update Notification Component (Closes #102)

Alert should appear right above the search bar in the extension window

Description:
- When there is an update available, the alert appears
- If closed by the user, it is locally set to never appear again until the extension is updated so that the next update will have the alert

Testing:
- **onUpdateAvailable and onInstalled chrome runtime methods I do not think have a local way to test them as far as I know**
- To view / see the alert functionality, set the alertVisibity state to true, it should appear in the extension window
- If you close it and it doesn't appear again, its working as intended but if you'd like to reset that you can copy and paste this piece of code in the console window when you inspect pop-up when you right click the extension. It should appear again when you reopen the extension window (assuming you have alertVisibility set to true in the code).

chrome.storage.local.set({ alertClosed: false }, () => {
  if (chrome.runtime.lastError) {
    console.error(chrome.runtime.lastError);
  }
});