### PR TITLE
Leaf/mint napkin/tos popup

### DIFF
--- a/TermsOfService.md
+++ b/TermsOfService.md
@@ -1,53 +1,61 @@
 # BroncoDirectMe Terms of Service
-Welcome to BroncoDirectMe! This Terms of Service ("Terms") outlines the terms and conditions governing the use of BroncoDirectMe's services, particularly with respect to the storage and handling of student information under the Family Educational Rights and Privacy Act (FERPA). Please read these Terms carefully before using our services. By accessing or using BroncoDirectMe, you agree to be bound by these Terms.
 
+Welcome to BroncoDirectMe! This Terms of Service ("Terms") outlines the terms and conditions governing the use of BroncoDirectMe's services, particularly with respect to the storage and handling of student information under the Family Educational Rights and Privacy Act (FERPA). Please read these Terms carefully before using our services. By accessing or using BroncoDirectMe, you agree to be bound by these Terms.
 
 ## 1. Introduction
 
-### 1.1 BroncoDirectMe Services 
+### 1.1 BroncoDirectMe Services
+
 BroncoDirectMe is a platform that provides educational services such as course registration information from RateMyProfessor and CPPScheduler. This document focuses on the storage of student information for the Degree Progress Report page in compliance with FERPA.
 
 ### 1.2 FERPA Compliance
+
 FERPA is a federal law that protects the privacy of student education records. BroncoDirectMe is committed to complying with FERPA and protecting the confidentiality and security of student information. As a student-led project, BroncoDirectMe wants to err on the side of caution when handling sensitive student education records.
 <br>
 <br>
 See the following links for more information concerning the legality of FERPA in BroncoDirectMe:
+
 - [To which educational agencies or institutions does FERPA apply?](https://studentprivacy.ed.gov/faq/which-educational-agencies-or-institutions-does-ferpa-apply)
 - [Is prior written consent of the parent or eligible student required to disclose information to community-based organizations?](https://studentprivacy.ed.gov/faq/prior-written-consent-parent-or-eligible-student-required-disclose-information-community-based)
 - [Who is responsible for obtaining written consent from the parent or eligible student: the school or the community-based organization?](https://studentprivacy.ed.gov/faq/who-responsible-obtaining-written-consent-parent-or-eligible-student-school-or-community-based)
 
-
 ## 2. Student Information
 
-### 2.1 Types of Student Information 
+### 2.1 Types of Student Information
+
 BroncoDirectMe may collect and store various types of student information, including but not limited to:
-   - Course registration and enrollment information
+
+- Course registration and enrollment information
 
 ### 2.2 Purpose of Student Information
-The collection and storage of student information are solely for the purpose of facilitating educational services, including academic advising and course registration.
 
+The collection and storage of student information are solely for the purpose of facilitating educational services, including academic advising and course registration.
 
 ## 3. Privacy and Security
 
 ### 3.1 Data Security
+
 We are committed to maintaining the confidentiality and integrity of student records. BroncoDirectMe will store your student information in accordance with the Family Educational Rights and Privacy Act (FERPA). This means that your information will be kept confidential and will not be shared with anyone without your permission. The data will be stored locally, meaning all confidential data will be stored on your computer’s browser and not on a cloud server.
 
 ### 3.2 Access Control
+
 BroncoDirectMe will not share your student information with any third parties. This means that your information will not be sold or given to other companies without your permission.
 
 ### 3.3 Data Retention
+
 BroncoDirectMe will not retain student information longer than necessary for its intended purpose.
 You have the right to have your student information deleted from BroncoDirectMe if you no longer wish to use the service. You can request to have your student information deleted at any time, and it will be deleted immediately.
-
 
 ## 4. Amendments to Terms
 
 ### 4.1 Updates
+
 BroncoDirectMe reserves the right to update these Terms to reflect changes in applicable laws, regulations, or our services. Users will be notified of any material changes to these Terms.
 
-
 ## 5. Contact Information
+
 ### 5.1 Questions
+
 For questions or concerns regarding these Terms or the storage of student information under FERPA, please contact BroncoDirectMe.
 
 By using BroncoDirectMe, you acknowledge that you have read and agree to these Terms of Service regarding the storage of student information under FERPA. Failure to comply with these Terms may result in disciplinary actions, including but not limited to legal consequences.

--- a/TermsOfService.md
+++ b/TermsOfService.md
@@ -1,0 +1,55 @@
+# BroncoDirectMe Terms of Service
+Welcome to BroncoDirectMe! This Terms of Service ("Terms") outlines the terms and conditions governing the use of BroncoDirectMe's services, particularly with respect to the storage and handling of student information under the Family Educational Rights and Privacy Act (FERPA). Please read these Terms carefully before using our services. By accessing or using BroncoDirectMe, you agree to be bound by these Terms.
+
+
+## 1. Introduction
+
+### 1.1 BroncoDirectMe Services 
+BroncoDirectMe is a platform that provides educational services such as course registration information from RateMyProfessor and CPPScheduler. This document focuses on the storage of student information for the Degree Progress Report page in compliance with FERPA.
+
+### 1.2 FERPA Compliance
+FERPA is a federal law that protects the privacy of student education records. BroncoDirectMe is committed to complying with FERPA and protecting the confidentiality and security of student information. As a student-led project, BroncoDirectMe wants to err on the side of caution when handling sensitive student education records.
+<br>
+<br>
+See the following links for more information concerning the legality of FERPA in BroncoDirectMe:
+- [To which educational agencies or institutions does FERPA apply?](https://studentprivacy.ed.gov/faq/which-educational-agencies-or-institutions-does-ferpa-apply)
+- [Is prior written consent of the parent or eligible student required to disclose information to community-based organizations?](https://studentprivacy.ed.gov/faq/prior-written-consent-parent-or-eligible-student-required-disclose-information-community-based)
+- [Who is responsible for obtaining written consent from the parent or eligible student: the school or the community-based organization?](https://studentprivacy.ed.gov/faq/who-responsible-obtaining-written-consent-parent-or-eligible-student-school-or-community-based)
+
+
+## 2. Student Information
+
+### 2.1 Types of Student Information 
+BroncoDirectMe may collect and store various types of student information, including but not limited to:
+   - Course registration and enrollment information
+
+### 2.2 Purpose of Student Information
+The collection and storage of student information are solely for the purpose of facilitating educational services, including academic advising and course registration.
+
+
+## 3. Privacy and Security
+
+### 3.1 Data Security
+We are committed to maintaining the confidentiality and integrity of student records. BroncoDirectMe will store your student information in accordance with the Family Educational Rights and Privacy Act (FERPA). This means that your information will be kept confidential and will not be shared with anyone without your permission. The data will be stored locally, meaning all confidential data will be stored on your computer’s browser and not on a cloud server.
+
+### 3.2 Access Control
+BroncoDirectMe will not share your student information with any third parties. This means that your information will not be sold or given to other companies without your permission.
+
+### 3.3 Data Retention
+BroncoDirectMe will not retain student information longer than necessary for its intended purpose.
+You have the right to have your student information deleted from BroncoDirectMe if you no longer wish to use the service. You can request to have your student information deleted at any time, and it will be deleted immediately.
+
+
+## 4. Amendments to Terms
+
+### 4.1 Updates
+BroncoDirectMe reserves the right to update these Terms to reflect changes in applicable laws, regulations, or our services. Users will be notified of any material changes to these Terms.
+
+
+## 5. Contact Information
+### 5.1 Questions
+For questions or concerns regarding these Terms or the storage of student information under FERPA, please contact BroncoDirectMe.
+
+By using BroncoDirectMe, you acknowledge that you have read and agree to these Terms of Service regarding the storage of student information under FERPA. Failure to comply with these Terms may result in disciplinary actions, including but not limited to legal consequences.
+
+**Effective Date:** September 25th, 2023

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import { Panel } from './components/panel_component';
 import DegreeProgressBar from './components/DegreeProgressBar';
 import './styles/App.css';
 import UpdateAlert from './components/UpdateAlert';
+import TermsOfService from './components/TermsOfService';
 
 /**
  * @returns Main app component
@@ -25,6 +26,7 @@ export function App(): ReactElement {
         {!isPanelOpen && (
           <section>
             <UpdateAlert />
+            <TermsOfService />
             <div id="errorElm"></div>
             <Box id="mainContent">
               <h1>BroncoDirectMe Search</h1>

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -91,7 +91,7 @@ function TermsOfService(): JSX.Element {
           <div className="tos-checkbox">
             <Checkbox onChange={handleCheck} />
             <Typography>
-              By checking this box you have read and accepted the{' '}
+              By checking this box, you accept the{' '}
               <a href={tos} target="_blank" rel="noopener noreferrer">
                 Terms of Service
               </a>{' '}

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -1,12 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import {
-  Typography,
-  Box,
-  Button,
-  Modal,
-  Checkbox,
-  FormControlLabel,
-} from '@mui/material';
+import { Alert, Typography, Box, Button, Modal, Checkbox } from '@mui/material';
 import '../styles/TermsOfService.css';
 
 /**
@@ -18,13 +11,17 @@ function TermsOfService(): JSX.Element {
   const [open, setOpen] = useState(false);
   const [checked, setChecked] = useState(false);
 
+  const tos =
+    'https://github.com/BroncoDirectMe/Frontend/blob/main/TermsOfService.md';
+
   useEffect(() => {
-    handleAgreementButton();
+    handleAgreementAlert();
   }, []);
 
   const handleOpen = (): void => setOpen(true);
   const handleClose = (): void => setOpen(false);
 
+  // handles checkbox state
   const handleCheck = (): void => {
     if (checked) {
       setChecked(false);
@@ -33,7 +30,8 @@ function TermsOfService(): JSX.Element {
     }
   };
 
-  const handleAgreementButton = (): void => {
+  //
+  const handleAgreementAlert = (): void => {
     chrome.storage.local.get('tosSigned', ({ tosSigned }) => {
       if (tosSigned) {
         setIsAgreed(true);
@@ -54,15 +52,18 @@ function TermsOfService(): JSX.Element {
         console.error(chrome.runtime.lastError);
       }
     });
-    handleAgreementButton();
+    handleAgreementAlert();
   };
 
   return (
     <div>
       {!isAgreed && (
-        <Button variant="outlined" onClick={handleOpen}>
-          TERMS OF SERVICE
-        </Button>
+        <Alert
+          severity="info"
+          action={<Button onClick={handleOpen}>GO</Button>}
+        >
+          Please read the Terms of Service.
+        </Alert>
       )}
       <Modal
         open={open}
@@ -83,39 +84,24 @@ function TermsOfService(): JSX.Element {
             p: 4,
           }}
         >
-          <div className="tos-header">
-            <Button
-              onClick={() => {
-                setOpen(false);
-                setChecked(false);
-              }}
-            >
-              BACK
-            </Button>
-            <Typography className="tos-title" variant="h6" component="h2">
-              Terms Of Service
+          <Button
+            onClick={() => {
+              setOpen(false);
+              setChecked(false);
+            }}
+          >
+            BACK
+          </Button>
+          <div className="tos-checkbox">
+            <Checkbox onChange={handleCheck} />
+            <Typography>
+              By checking this box you have read and accepted{' '}
+              <a href={tos} target="_blank" rel="noopener noreferrer">
+                Terms of Service
+              </a>{' '}
+              of BroncoDirectMe
             </Typography>
           </div>
-          <Typography className="tos-description">
-            Duis mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
-            mollis, est non commodo luctus, nisi erat porttitor ligula.
-          </Typography>
-          <FormControlLabel
-            control={<Checkbox onChange={handleCheck} />}
-            label="I have read and agree to the Terms of Service"
-          />
           <div className="tos-button">
             <Button onClick={handleAgreement} disabled={!checked}>
               CONFIRM

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -23,11 +23,7 @@ function TermsOfService(): JSX.Element {
 
   // handles checkbox state
   const handleCheck = (): void => {
-    if (checked) {
-      setChecked(false);
-    } else {
-      setChecked(true);
-    }
+    setChecked(!checked);
   };
 
   //

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -67,7 +67,11 @@ function TermsOfService(): JSX.Element {
       )}
       <Modal
         open={open}
-        onClose={handleClose}
+        onClose={() => {
+          handleClose();
+          setOpen(false);
+          setChecked(false);
+        }}
         aria-labelledby="tos-title"
         aria-describedby="tos-description"
       >
@@ -84,18 +88,10 @@ function TermsOfService(): JSX.Element {
             p: 4,
           }}
         >
-          <Button
-            onClick={() => {
-              setOpen(false);
-              setChecked(false);
-            }}
-          >
-            BACK
-          </Button>
           <div className="tos-checkbox">
             <Checkbox onChange={handleCheck} />
             <Typography>
-              By checking this box you have read and accepted{' '}
+              By checking this box you have read and accepted the{' '}
               <a href={tos} target="_blank" rel="noopener noreferrer">
                 Terms of Service
               </a>{' '}

--- a/src/components/TermsOfService.tsx
+++ b/src/components/TermsOfService.tsx
@@ -1,0 +1,89 @@
+import React, { useState } from 'react';
+import {
+  Typography,
+  Box,
+  Button,
+  Modal,
+  Checkbox,
+  FormControlLabel,
+} from '@mui/material';
+import '../styles/TermsOfService.css';
+
+/**
+ * Terms Of Service Popup Component
+ * @returns Div containing the professor popup element
+ */
+function TermsOfService(): JSX.Element {
+  const [open, setOpen] = useState(false);
+  const [checked, setChecked] = useState(false);
+
+  const handleOpen = (): void => setOpen(true);
+  const handleClose = (): void => setOpen(false);
+
+  const handleCheck = (): void => {
+    if (checked) {
+      setChecked(false);
+    } else {
+      setChecked(true);
+    }
+  };
+
+  return (
+    <div>
+      <Button variant="outlined" onClick={handleOpen}>
+        TERMS OF SERVICE
+      </Button>
+      <Modal
+        open={open}
+        onClose={handleClose}
+        aria-labelledby="tos-title"
+        aria-describedby="tos-description"
+      >
+        <Box
+          sx={{
+            position: 'absolute' as 'absolute',
+            top: '50%',
+            left: '50%',
+            transform: 'translate(-50%, -50%)',
+            width: 400,
+            bgcolor: 'background.paper',
+            border: '2px solid #000',
+            boxShadow: 24,
+            p: 4,
+          }}
+        >
+          <Typography className="tos-title" variant="h6" component="h2">
+            Terms Of Service
+          </Typography>
+          <Typography className="tos-description">
+            Duis mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula. Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula.Duis
+            mollis, est non commodo luctus, nisi erat porttitor ligula.
+          </Typography>
+          <FormControlLabel
+            control={<Checkbox onChange={handleCheck} />}
+            label="I have read and agree to the Terms of Service"
+          />
+          <div className="tos-button">
+            <Button onClick={() => setOpen(false)} disabled={!checked}>
+              CONFIRM
+            </Button>
+          </div>
+        </Box>
+      </Modal>
+    </div>
+  );
+}
+
+export default TermsOfService;

--- a/src/styles/TermsOfService.css
+++ b/src/styles/TermsOfService.css
@@ -1,0 +1,26 @@
+.tos-title {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+.tos-description {
+  margin-top: 2;
+  max-height: 150px;
+  overflow: auto;
+  border: 2px solid #000000;
+}
+
+.tos-description::-webkit-scrollbar {
+  width: 12px; 
+}
+
+.tos-description::-webkit-scrollbar-thumb {
+  background-color: #999;
+}
+
+.tos-button{
+    display: flex;
+    justify-content: right;
+    align-items: center;
+}

--- a/src/styles/TermsOfService.css
+++ b/src/styles/TermsOfService.css
@@ -1,27 +1,7 @@
-.tos-header {
-  position: relative;
-  display: flex;
-}
-
-.tos-title {
+.tos-checkbox {
   display: flex;
   justify-content: center;
   align-items: center;
-}
-
-.tos-description {
-  margin-top: 2;
-  max-height: 150px;
-  overflow: auto;
-  border: 2px solid #000000;
-}
-
-.tos-description::-webkit-scrollbar {
-  width: 12px;
-}
-
-.tos-description::-webkit-scrollbar-thumb {
-  background-color: #999;
 }
 
 .tos-button {


### PR DESCRIPTION
Terms of Service Component that alerts the user to read and agree to the terms of service. Alert disappears after the user confirms they have read the Terms of Service.

NOTES:
- Hyperlink does not lead directly to the TOS yet, it leads to the TermsOfService.md file url on github when it eventually goes to main branch so that it doesn't point toward a dev branch

- When you test and press the 'confirm' button after agreeing to TOS, the alert will not appear again. If you want to see the alert again: right click on the extension, inspect popup, and copy and paste this into the console

  chrome.storage.local.set({ tosSigned: false }, () => {
    if (chrome.runtime.lastError) {
     console.error(chrome.runtime.lastError);
    }
  });


Close #101 