### PR TITLE
Leaf/tdang2180/report missing professor button

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,7 +16,8 @@
         "@mui/icons-material": "^5.11.11",
         "@mui/material": "^5.10.6",
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-hook-form": "^7.47.0"
       },
       "devDependencies": {
         "@babel/core": "^7.18.13",
@@ -7571,6 +7572,21 @@
         "react": "^18.2.0"
       }
     },
+    "node_modules/react-hook-form": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
+      "engines": {
+        "node": ">=12.22.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/react-hook-form"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17 || ^18"
+      }
+    },
     "node_modules/react-is": {
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
@@ -14586,6 +14602,12 @@
         "loose-envify": "^1.1.0",
         "scheduler": "^0.23.0"
       }
+    },
+    "react-hook-form": {
+      "version": "7.47.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.47.0.tgz",
+      "integrity": "sha512-F/TroLjTICipmHeFlMrLtNLceO2xr1jU3CyiNla5zdwsGUGu2UOxxR4UyJgLlhMwLW/Wzp4cpJ7CPfgJIeKdSg==",
+      "requires": {}
     },
     "react-is": {
       "version": "16.13.1",

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "@mui/icons-material": "^5.11.11",
     "@mui/material": "^5.10.6",
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-hook-form": "^7.47.0"
   }
 }

--- a/src/components/ProfessorPopup.tsx
+++ b/src/components/ProfessorPopup.tsx
@@ -13,6 +13,7 @@ import FmdBadIcon from '@mui/icons-material/FmdBad';
 import NavigateBeforeIcon from '@mui/icons-material/NavigateBefore';
 import NavigateNextIcon from '@mui/icons-material/NavigateNext';
 import RateMyProfessorButton from './RateMyProfessorButton';
+import ReportMissingProfesor from './ReportMissingProfessor';
 import '../styles/ProfessorPopup.css';
 
 interface professorPopupTooltipProps {
@@ -222,6 +223,9 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
           <div className="error center-items">
             <FmdBadIcon id="error-icon" />
             <Typography id="error-message">{errorMessage}</Typography>
+            {errorMessage.includes('does not have') && (
+              <ReportMissingProfesor openForm={false} />
+            )}
           </div>
         )}
 

--- a/src/components/ProfessorPopup.tsx
+++ b/src/components/ProfessorPopup.tsx
@@ -224,7 +224,7 @@ function ProfessorPopupInfo(props: professorPopupTooltipProps): JSX.Element {
             <FmdBadIcon id="error-icon" />
             <Typography id="error-message">{errorMessage}</Typography>
             {errorMessage.includes('does not have') && (
-              <ReportMissingProfesor openForm={false} />
+              <ReportMissingProfesor openForm={true} />
             )}
           </div>
         )}

--- a/src/components/ReportMissingProfessor.tsx
+++ b/src/components/ReportMissingProfessor.tsx
@@ -29,10 +29,12 @@ interface CustomTextFieldProps {
 
 /**
  * Missing professor report component constructor
- * @param openForm - Open form if boolean value is true
+ * @param props.openForm - Open form if boolean value is true
  * @returns {JSX.Element} - Missing professor report component
  */
-export default function ReportMissingProfesor(props: { openForm: boolean }) {
+export default function ReportMissingProfesor(props: {
+  openForm: boolean;
+}): JSX.Element {
   const [reportState, setReportState] = useState(false);
   const [submitState, setSubmitState] = useState(false);
 
@@ -47,10 +49,10 @@ export default function ReportMissingProfesor(props: { openForm: boolean }) {
 
   /**
    * Error icon pop up component constructor
-   * @param title - Tooltip's title
+   * @param props.title - Tooltip's title
    * @returns {JSX.Element} - Error icon component
    */
-  const InvalidError = (props: { title: string }) => {
+  const InvalidError = (props: { title: string }): JSX.Element => {
     return (
       <Tooltip title={props.title}>
         <ErrorIcon color="error" />
@@ -63,7 +65,7 @@ export default function ReportMissingProfesor(props: { openForm: boolean }) {
    * @param {CustomTextFieldProps} props - The props object containing custom text field's args
    * @returns {JSX.Element} - Custom text field component
    */
-  const CustomTextField = (props: CustomTextFieldProps) => {
+  const CustomTextField = (props: CustomTextFieldProps): JSX.Element => {
     const [text, setText] = useState(props.text);
 
     function handleTextChange(event: any) {
@@ -97,7 +99,7 @@ export default function ReportMissingProfesor(props: { openForm: boolean }) {
    * Text field form component constructor
    * @returns {JSX.Element} - Text field form component
    */
-  const TextFieldForm = () => {
+  const TextFieldForm = (): JSX.Element => {
     const {
       handleSubmit,
       register,
@@ -150,7 +152,7 @@ export default function ReportMissingProfesor(props: { openForm: boolean }) {
    * Missing professor form component constructor
    * @returns {JSX.Element} - Missing professor form component
    */
-  const MissingProfessorForm = () => {
+  const MissingProfessorForm = (): JSX.Element => {
     return (
       <Modal open={reportState} id="modal-form">
         <Grid container id="modal-form-container">

--- a/src/components/ReportMissingProfessor.tsx
+++ b/src/components/ReportMissingProfessor.tsx
@@ -115,11 +115,9 @@ export default function ReportMissingProfesor(props: {
       <Grid item container xs={12} id="form-container">
         <form
           onSubmit={handleSubmit((data) => {
-            void (async () => {
-              console.log(data);
-              setReportState(false);
-              setSubmitState(true);
-            });
+            console.log(data);
+            setReportState(false);
+            setSubmitState(true);
           })}
         >
           <Grid item container id="form-component-container">

--- a/src/components/ReportMissingProfessor.tsx
+++ b/src/components/ReportMissingProfessor.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from 'react';
+
+import {
+  Grid,
+  Typography,
+  Button,
+  TextField,
+  Modal,
+  FormControl,
+} from '@mui/material';
+
+export default function ReportMissingProfesor() {
+  const [reportState, setReportState] = useState(false);
+
+  const handleButtonClick = () => {
+    setReportState(true);
+  };
+
+  const handleOnSubmit = () => {
+    setReportState(false);
+  };
+
+  const handleOnCancel = () => {
+    setReportState(false);
+  };
+
+  const TextFieldBox = (props: {
+    label: string;
+    placeholder: string;
+    text: string;
+    charLimit: number;
+  }) => {
+    return (
+      <FormControl required fullWidth>
+        <TextField
+          variant="outlined"
+          label={props.label}
+          placeholder={props.placeholder}
+        >
+          {props.text}
+        </TextField>
+      </FormControl>
+    );
+  };
+
+  const TextFieldForm = () => {
+    return (
+      <Grid item container xs={12} margin="10px 15px 0px 15px">
+        <Grid item container justifyContent="center" xs={12}>
+          <Typography fontWeight="bold" fontSize="17px">
+            Missing Professor Report
+          </Typography>
+        </Grid>
+
+        <Grid item container gap="10px" justifyContent="right">
+          <TextFieldBox
+            label="Name"
+            placeholder="Enter professor's name"
+            text=""
+            charLimit={40}
+          />
+          <TextFieldBox
+            label="Course/Major"
+            placeholder="Enter course's name and number"
+            text=""
+            charLimit={40}
+          />
+        </Grid>
+
+        <Grid item container xs={12} justifyContent="right" mb="5px">
+          <Button onClick={handleOnCancel}>Cancel</Button>
+          <Button onClick={handleOnSubmit}>Submit</Button>
+        </Grid>
+      </Grid>
+    );
+  };
+
+  const MissingProfessorForm = () => {
+    return (
+      <Modal
+        open={reportState}
+        sx={{
+          display: 'flex',
+          justifyContent: 'center',
+          alignItems: 'center',
+        }}
+      >
+        <Grid
+          container
+          width="375px"
+          height="225px"
+          bgcolor="white"
+          borderRadius="10px"
+        >
+          <TextFieldForm />
+        </Grid>
+      </Modal>
+    );
+  };
+
+  return (
+    <Grid container alignItems="center" justifyContent="center">
+      <Button onClick={handleButtonClick}>
+        <Typography fontSize="13px"> Report Missing Professor </Typography>
+      </Button>
+      <MissingProfessorForm />
+    </Grid>
+  );
+}

--- a/src/components/ReportMissingProfessor.tsx
+++ b/src/components/ReportMissingProfessor.tsx
@@ -73,7 +73,6 @@ export default function ReportMissingProfesor(props: {
     /**
      * Helper function to limit text's length
      * @param event event parameter
-     * @returns nothing
      */
     function handleTextChange(event: any): void {
       if (event.target.value.length > 40) return;
@@ -116,9 +115,11 @@ export default function ReportMissingProfesor(props: {
       <Grid item container xs={12} id="form-container">
         <form
           onSubmit={handleSubmit((data) => {
-            console.log(data);
-            setReportState(false);
-            setSubmitState(true);
+            void (async () => {
+              console.log(data);
+              setReportState(false);
+              setSubmitState(true);
+            });
           })}
         >
           <Grid item container id="form-component-container">

--- a/src/components/ReportMissingProfessor.tsx
+++ b/src/components/ReportMissingProfessor.tsx
@@ -1,4 +1,6 @@
 import React, { useState } from 'react';
+import { useForm, UseFormRegister, FieldError } from 'react-hook-form';
+import ErrorIcon from '@mui/icons-material/Error';
 
 import {
   Grid,
@@ -6,92 +8,152 @@ import {
   Button,
   TextField,
   Modal,
-  FormControl,
+  Tooltip,
 } from '@mui/material';
+import '../styles/ReportMissingProfessor.css';
 
-export default function ReportMissingProfesor() {
+interface IFormInputs {
+  name: string;
+  department: string;
+}
+
+interface CustomTextFieldProps {
+  label: string;
+  text: string;
+  placeholder: string;
+  register: UseFormRegister<IFormInputs>;
+  title: string;
+  errorField: FieldError | undefined;
+  fieldName: 'name' | 'department';
+}
+
+/**
+ * Missing professor report component constructor
+ * @param openForm - Open form if boolean value is true
+ * @returns {JSX.Element} - Missing professor report component
+ */
+export default function ReportMissingProfesor(props: { openForm: boolean }) {
   const [reportState, setReportState] = useState(false);
+  const [submitState, setSubmitState] = useState(false);
 
   const handleButtonClick = () => {
     setReportState(true);
-  };
-
-  const handleOnSubmit = () => {
-    setReportState(false);
+    if (!props.openForm) setSubmitState(true);
   };
 
   const handleOnCancel = () => {
     setReportState(false);
   };
 
-  const TextFieldBox = (props: {
-    label: string;
-    placeholder: string;
-    text: string;
-    charLimit: number;
-  }) => {
+  /**
+   * Error icon pop up component constructor
+   * @param title - Tooltip's title
+   * @returns {JSX.Element} - Error icon component
+   */
+  const InvalidError = (props: { title: string }) => {
     return (
-      <FormControl required fullWidth>
-        <TextField
-          variant="outlined"
-          label={props.label}
-          placeholder={props.placeholder}
-        >
-          {props.text}
-        </TextField>
-      </FormControl>
+      <Tooltip title={props.title}>
+        <ErrorIcon color="error" />
+      </Tooltip>
     );
   };
 
-  const TextFieldForm = () => {
+  /**
+   * Custom text field component constructor
+   * @param {CustomTextFieldProps} props - The props object containing custom text field's args
+   * @returns {JSX.Element} - Custom text field component
+   */
+  const CustomTextField = (props: CustomTextFieldProps) => {
+    const [text, setText] = useState(props.text);
+
+    function handleTextChange(event: any) {
+      if (event.target.value.length > 40) return;
+      setText(event.target.value);
+    }
+
     return (
-      <Grid item container xs={12} margin="10px 15px 0px 15px">
-        <Grid item container justifyContent="center" xs={12}>
-          <Typography fontWeight="bold" fontSize="17px">
-            Missing Professor Report
-          </Typography>
-        </Grid>
+      <TextField
+        fullWidth
+        value={text}
+        placeholder={props.placeholder}
+        label={props.label}
+        {...props.register(props.fieldName, {
+          required: true,
+          onChange: (e) => {
+            handleTextChange(e);
+          },
+        })}
+        {...(props.errorField && {
+          color: 'error',
+          InputProps: {
+            endAdornment: <InvalidError title={props.title + ' is required'} />,
+          },
+        })}
+      />
+    );
+  };
 
-        <Grid item container gap="10px" justifyContent="right">
-          <TextFieldBox
-            label="Name"
-            placeholder="Enter professor's name"
-            text=""
-            charLimit={40}
-          />
-          <TextFieldBox
-            label="Course/Major"
-            placeholder="Enter course's name and number"
-            text=""
-            charLimit={40}
-          />
-        </Grid>
-
-        <Grid item container xs={12} justifyContent="right" mb="5px">
-          <Button onClick={handleOnCancel}>Cancel</Button>
-          <Button onClick={handleOnSubmit}>Submit</Button>
-        </Grid>
+  /**
+   * Text field form component constructor
+   * @returns {JSX.Element} - Text field form component
+   */
+  const TextFieldForm = () => {
+    const {
+      handleSubmit,
+      register,
+      formState: { errors },
+    } = useForm<IFormInputs>();
+    return (
+      <Grid item container xs={12} id="form-container">
+        <form
+          onSubmit={handleSubmit((data) => {
+            console.log(data);
+            setReportState(false);
+            setSubmitState(true);
+          })}
+        >
+          <Grid item container id="form-component-container">
+            <Grid item container xs={12} id="form-header-container">
+              <Typography fontWeight="bold" fontSize="17px">
+                Missing Professor Report
+              </Typography>
+            </Grid>
+            <CustomTextField
+              label="Name*"
+              text=""
+              placeholder="Enter professor's name"
+              register={register}
+              title="Name"
+              errorField={errors.name}
+              fieldName="name"
+            />
+            <CustomTextField
+              label="Department*"
+              text=""
+              placeholder="Enter professor's department"
+              register={register}
+              title="Department"
+              errorField={errors.department}
+              fieldName="department"
+            />
+            <Grid item container xs={12} id="form-button-container">
+              <Button onClick={handleOnCancel}>Cancel</Button>
+              <Button type="submit">Submit</Button>
+            </Grid>
+          </Grid>
+        </form>
       </Grid>
     );
   };
 
+  /**
+   * Missing professor form component constructor
+   * @returns {JSX.Element} - Missing professor form component
+   */
   const MissingProfessorForm = () => {
     return (
-      <Modal
-        open={reportState}
-        sx={{
-          display: 'flex',
-          justifyContent: 'center',
-          alignItems: 'center',
-        }}
-      >
-        <Grid
-          container
-          width="375px"
-          height="225px"
-          bgcolor="white"
-          borderRadius="10px"
-        >
+      <Modal open={reportState} id="modal-form">
+        <Grid container id="modal-form-container">
           <TextFieldForm />
         </Grid>
       </Modal>
@@ -99,11 +161,17 @@ export default function ReportMissingProfesor() {
   };
 
   return (
-    <Grid container alignItems="center" justifyContent="center">
-      <Button onClick={handleButtonClick}>
-        <Typography fontSize="13px"> Report Missing Professor </Typography>
-      </Button>
-      <MissingProfessorForm />
+    <Grid container id="button-container">
+      {submitState ? (
+        <Typography fontSize="15px" fontWeight="bold" color="#3cb043">
+          Missing Professor Report submitted!
+        </Typography>
+      ) : (
+        <Button onClick={handleButtonClick} id="button">
+          <Typography fontSize="13px"> Report Missing Professor </Typography>
+        </Button>
+      )}
+      {props.openForm && <MissingProfessorForm />}
     </Grid>
   );
 }

--- a/src/components/ReportMissingProfessor.tsx
+++ b/src/components/ReportMissingProfessor.tsx
@@ -29,6 +29,7 @@ interface CustomTextFieldProps {
 
 /**
  * Missing professor report component constructor
+ * @param props - properties
  * @param props.openForm - Open form if boolean value is true
  * @returns {JSX.Element} - Missing professor report component
  */
@@ -38,17 +39,18 @@ export default function ReportMissingProfesor(props: {
   const [reportState, setReportState] = useState(false);
   const [submitState, setSubmitState] = useState(false);
 
-  const handleButtonClick = () => {
+  const handleButtonClick = (): void => {
     setReportState(true);
     if (!props.openForm) setSubmitState(true);
   };
 
-  const handleOnCancel = () => {
+  const handleOnCancel = (): void => {
     setReportState(false);
   };
 
   /**
    * Error icon pop up component constructor
+   * @param props - properties
    * @param props.title - Tooltip's title
    * @returns {JSX.Element} - Error icon component
    */
@@ -68,7 +70,12 @@ export default function ReportMissingProfesor(props: {
   const CustomTextField = (props: CustomTextFieldProps): JSX.Element => {
     const [text, setText] = useState(props.text);
 
-    function handleTextChange(event: any) {
+    /**
+     * Helper function to limit text's length
+     * @param event event parameter
+     * @returns nothing
+     */
+    function handleTextChange(event: any): void {
       if (event.target.value.length > 40) return;
       setText(event.target.value);
     }

--- a/src/components/ReportMissingProfessor.tsx
+++ b/src/components/ReportMissingProfessor.tsx
@@ -111,14 +111,17 @@ export default function ReportMissingProfesor(props: {
       register,
       formState: { errors },
     } = useForm<IFormInputs>();
+
+    const onSubmitClick = (): void => {
+      setReportState(false);
+      setSubmitState(true);
+    };
+
     return (
       <Grid item container xs={12} id="form-container">
         <form
-          onSubmit={handleSubmit((data) => {
-            console.log(data);
-            setReportState(false);
-            setSubmitState(true);
-          })}
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
+          onSubmit={handleSubmit(onSubmitClick)}
         >
           <Grid item container id="form-component-container">
             <Grid item container xs={12} id="form-header-container">

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -275,7 +275,7 @@ export default function SearchBar({
               {"Sorry, we couldn't find any results for your search."}
             </Typography>
           </div>
-          <ReportMissingProfesor />
+          <ReportMissingProfesor openForm={true} />
         </>
       )}
       {/* Conditional React rendering for result and no result */}

--- a/src/components/SearchBar.tsx
+++ b/src/components/SearchBar.tsx
@@ -3,9 +3,11 @@ import {
   Autocomplete,
   createFilterOptions,
   CircularProgress,
+  Typography,
 } from '@mui/material';
 import React, { CSSProperties, useState, useEffect } from 'react';
 import RateMyProfessorButton from './RateMyProfessorButton';
+import ReportMissingProfesor from './ReportMissingProfessor';
 import '../styles/SearchBar.css';
 
 let searchView: CSSProperties = {
@@ -267,9 +269,14 @@ export default function SearchBar({
         </section>
       )}
       {!hasResult && (
-        <div id="noResult">
-          <h3>{"Sorry, we couldn't find any results for your search."}</h3>
-        </div>
+        <>
+          <div id="noResult">
+            <Typography fontWeight="bold" fontSize="15px">
+              {"Sorry, we couldn't find any results for your search."}
+            </Typography>
+          </div>
+          <ReportMissingProfesor />
+        </>
       )}
       {/* Conditional React rendering for result and no result */}
     </div>

--- a/src/styles/ProfessorPopup.css
+++ b/src/styles/ProfessorPopup.css
@@ -63,6 +63,7 @@
   border-radius: 50%;
   border: none;
   box-shadow: 0 0 8px rgba(0, 0, 0, 0.2);
+  margin: 0px 18px;
 }
 
 .popup-tooltip {

--- a/src/styles/ReportMissingProfessor.css
+++ b/src/styles/ReportMissingProfessor.css
@@ -1,0 +1,39 @@
+#button-container {
+  justify-content: center;
+  align-items: center;
+}
+
+#button {
+  display: flex;
+  align-items: center;
+}
+
+#modal-form {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+
+#modal-form-container {
+  width: 375px;
+  height: 225px;
+  background-color: white;
+  border-radius: 10px;
+}
+
+#form-container {
+  margin: 10px 15px 0px 15px;
+}
+
+#form-component-container {
+  gap: 10px;
+}
+
+#form-button-container {
+  justify-content: right;
+  margin-bottom: 5px;
+}
+
+#form-header-container {
+  justify-content: center;
+}

--- a/src/styles/SearchBar.css
+++ b/src/styles/SearchBar.css
@@ -90,5 +90,4 @@
 
 #noResult {
   text-align: center;
-  margin-bottom: 20px;
 }


### PR DESCRIPTION
resolves #38 
what would pluto do
**Features:**

- Button to report missing professor on both professor pop-up and search bar 
- Modal component with missing professor report form
- Used react hook form to check if the text fields are blank on submit
- Customized text field component to display error icon and limit text's length
- Fixed professor pop-up and search bar spacing 

I don't think this form should automatically add the missing professor into the database with blank information, but there should be a way to check the user's input and manually add it to the database if the information is valid. 

<img width = "50%" src = https://github.com/BroncoDirectMe/Frontend/assets/114024874/f20c4560-d85a-4afb-8518-a5b293da2bc1/>

<img width = "60%" src = https://github.com/BroncoDirectMe/Frontend/assets/114024874/3af07615-b7dc-4ad5-b8dc-f8549328d147/>

<img width = "50%" length = "30%" src = https://github.com/BroncoDirectMe/Frontend/assets/114024874/2ddea3e2-e396-40ad-b8a1-d1405a835698/>


